### PR TITLE
Add run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,6 +13,9 @@ source:
 build:
   skip: True  # [not linux]
   number: 0
+  # https://github.com/01org/intel-hybrid-driver/blob/master/NEWS
+  run_exports:
+  - {{ pin_subpackage('intel-hybrid-driver', max_pin='x.x') }}
   # https://01.org/linuxgraphics/documentation/build-guide-0
   script:
     - ./autogen.sh --prefix=$PREFIX
@@ -26,9 +29,6 @@ requirements:
     - libtool
     - pkg-config
   host:
-    - libdrm
-    - cmrt
-  run:
     - libdrm
     - cmrt
 


### PR DESCRIPTION
@sodre, same logic, this is a new library, but it is 1.0 and intel's comments seem backward compatible for now between patch versions.


Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
